### PR TITLE
Add session retro commands for targeted workflow improvements

### DIFF
--- a/.claude/commands/session-retro-apply.md
+++ b/.claude/commands/session-retro-apply.md
@@ -1,31 +1,36 @@
 ---
-argument-hint: [confirmed-change]
-description: Apply one user-confirmed retrospective change
+argument-hint: [confirmed-problem-or-fix]
+description: Explore or apply one user-confirmed retrospective problem
 model: sonnet
 ---
 
-Implement exactly one confirmed retrospective change: $ARGUMENTS
+Work on exactly one confirmed retrospective problem or explicit requested fix: $ARGUMENTS
 
-Use the current conversation, including earlier `/session-retro` discussion, as supporting context. If the request is ambiguous, bundles multiple changes, or does not clearly identify one confirmed change, do not edit anything. Ask the user to narrow it to one change.
+Use the current conversation, including earlier `/session-retro` discussion, as supporting context. If the request is ambiguous, bundles multiple problems or fixes, or does not clearly identify one confirmed problem, do not edit anything. Ask the user to narrow it to one problem.
 
 Your job:
-1. Restate the requested change.
+1. Restate the requested focus.
 2. Define the exact scope.
-3. Make only that change.
-4. Verify the relevant result.
-5. Summarize what changed and any remaining follow-up.
+3. If the user has not chosen a fix yet, propose the smallest durable solution options for that one problem only.
+4. If the user has chosen a fix explicitly, make only that change.
+5. Verify any implemented result.
+6. Summarize what changed and any remaining follow-up.
 
 Rules:
 - Do not reopen the whole retrospective.
 - Do not silently implement adjacent improvements.
-- Prefer the smallest durable edit that satisfies the request.
+- Prefer the smallest durable fix that addresses the confirmed problem.
 - Verify before claiming success.
 
 Output exactly these sections:
 
-## Requested change
+## Requested focus
 
 ## Planned scope
+
+## Solution options
+
+## Recommended next step
 
 ## Changes made
 

--- a/.claude/commands/session-retro-apply.md
+++ b/.claude/commands/session-retro-apply.md
@@ -1,0 +1,33 @@
+---
+argument-hint: [confirmed-change]
+description: Apply one user-confirmed retrospective change
+---
+
+Implement exactly one confirmed retrospective change: $ARGUMENTS
+
+Use the current conversation, including earlier `/session-retro` discussion, as supporting context. If the request is ambiguous, bundles multiple changes, or does not clearly identify one confirmed change, do not edit anything. Ask the user to narrow it to one change.
+
+Your job:
+1. Restate the requested change.
+2. Define the exact scope.
+3. Make only that change.
+4. Verify the relevant result.
+5. Summarize what changed and any remaining follow-up.
+
+Rules:
+- Do not reopen the whole retrospective.
+- Do not silently implement adjacent improvements.
+- Prefer the smallest durable edit that satisfies the request.
+- Verify before claiming success.
+
+Output exactly these sections:
+
+## Requested change
+
+## Planned scope
+
+## Changes made
+
+## Verification
+
+## Remaining follow-up

--- a/.claude/commands/session-retro-apply.md
+++ b/.claude/commands/session-retro-apply.md
@@ -1,6 +1,7 @@
 ---
 argument-hint: [confirmed-change]
 description: Apply one user-confirmed retrospective change
+model: sonnet
 ---
 
 Implement exactly one confirmed retrospective change: $ARGUMENTS

--- a/.claude/commands/session-retro.md
+++ b/.claude/commands/session-retro.md
@@ -1,0 +1,49 @@
+---
+description: Analyze the current session for repo-side improvements that would have reduced wasted motion
+---
+
+Analyze the current live Claude Code session only.
+
+Treat the visible conversation, tool calls, and files discussed in this session as evidence. If earlier context appears missing due to compaction, say so explicitly and lower confidence rather than inventing explanations.
+
+Your job is analysis only. Do not propose implementation steps, do not edit files, and do not tell the user to change how they prompt. Recommend only repo-side changes such as updates to `CLAUDE.md` or `AGENTS.md`, comments, examples, helper docs, small refactors, or helper scripts.
+
+Use this process:
+
+1. State the session goal.
+2. Reconstruct the path the agent took.
+3. Identify concrete friction points with evidence from the session.
+4. For each friction point, explain why the detour made sense at the time.
+5. Map each friction point to exactly one primary fix type:
+   - `instruction gap`
+   - `comment gap`
+   - `example gap`
+   - `boundary gap`
+   - `workflow gap`
+6. Rank findings by likely future token or time savings.
+7. Return only the 3-5 highest-leverage findings.
+8. Stop and ask the user which items to keep, merge, drop, or reprioritize.
+
+Output exactly these sections:
+
+## Session goal
+
+## Path summary
+
+## Top findings
+
+For each finding, include:
+- `Observed friction`
+- `Why it happened`
+- `Recommended repo change`
+- `Why this should save tokens`
+- `Confidence`
+
+## Shortlist to confirm
+
+## Question
+
+Guardrails:
+- Do not produce generic "improve docs" advice.
+- Name the exact file or code area when possible.
+- If no meaningful wasted motion is visible, say so directly.

--- a/.claude/commands/session-retro.md
+++ b/.claude/commands/session-retro.md
@@ -1,5 +1,5 @@
 ---
-description: Analyze the current session for repo-side improvements that would have reduced wasted motion
+description: Analyze the current session for repo-side problems that likely caused wasted motion
 model: sonnet
 ---
 
@@ -7,7 +7,7 @@ Analyze the current live Claude Code session only.
 
 Treat the visible conversation, tool calls, and files discussed in this session as evidence. If earlier context appears missing due to compaction, say so explicitly and lower confidence rather than inventing explanations.
 
-Your job is analysis only. Do not propose implementation steps, do not edit files, and do not tell the user to change how they prompt. Recommend only repo-side changes such as updates to `CLAUDE.md` or `AGENTS.md`, comments, examples, helper docs, small refactors, or helper scripts.
+Your job is problem analysis only. Do not suggest fixes, do not propose implementation steps, do not edit files, and do not tell the user to change how they prompt.
 
 Use this process:
 
@@ -15,12 +15,12 @@ Use this process:
 2. Reconstruct the path the agent took.
 3. Identify concrete friction points with evidence from the session.
 4. For each friction point, explain why the detour made sense at the time.
-5. Map each friction point to exactly one primary fix type:
-   - `instruction gap`
-   - `comment gap`
-   - `example gap`
-   - `boundary gap`
-   - `workflow gap`
+5. Map each friction point to exactly one primary problem classification:
+   - `instruction ambiguity`
+   - `missing local explanation`
+   - `missing concrete example`
+   - `boundary opacity`
+   - `workflow friction`
 6. Rank findings by likely future token or time savings.
 7. Return only the 3-5 highest-leverage findings.
 8. Stop and ask the user which items to keep, merge, drop, or reprioritize.
@@ -34,10 +34,11 @@ Output exactly these sections:
 ## Top findings
 
 For each finding, include:
-- `Observed friction`
-- `Why it happened`
-- `Recommended repo change`
-- `Why this should save tokens`
+- `Observed problem`
+- `Why the agent hit it`
+- `Evidence from the session`
+- `Problem classification`
+- `Priority`
 - `Confidence`
 
 ## Shortlist to confirm
@@ -45,6 +46,7 @@ For each finding, include:
 ## Question
 
 Guardrails:
+- Do not recommend fixes or repo changes yet.
 - Do not produce generic "improve docs" advice.
 - Name the exact file or code area when possible.
 - If no meaningful wasted motion is visible, say so directly.

--- a/.claude/commands/session-retro.md
+++ b/.claude/commands/session-retro.md
@@ -1,5 +1,6 @@
 ---
 description: Analyze the current session for repo-side improvements that would have reduced wasted motion
+model: sonnet
 ---
 
 Analyze the current live Claude Code session only.

--- a/.claude/commands/session-retro.md
+++ b/.claude/commands/session-retro.md
@@ -1,5 +1,5 @@
 ---
-description: Analyze the current session for repo-side problems that likely caused wasted motion
+description: Analyze the current session for problems that likely caused wasted motion
 model: sonnet
 ---
 
@@ -13,7 +13,9 @@ Use this process:
 
 1. State the session goal.
 2. Reconstruct the path the agent took.
-3. Identify concrete friction points with evidence from the session.
+3. Identify concrete friction points with evidence from the session. Inspect two dimensions:
+   - **Repo-side**: missing instructions, ambiguous docs, undocumented conventions, conflicting guidance
+   - **Agent-internal**: tool selection, search strategy, parallelization choices, agent dispatch scope, reactive vs. anticipatory file reads, precondition checking before actions
 4. For each friction point, explain why the detour made sense at the time.
 5. Map each friction point to exactly one primary problem classification:
    - `instruction ambiguity`
@@ -21,6 +23,9 @@ Use this process:
    - `missing concrete example`
    - `boundary opacity`
    - `workflow friction`
+   - `agent: tool selection` — wrong tool for the task (Agent when Read/Grep sufficed, or vice versa)
+   - `agent: missed parallelism` — sequential tool calls that could have been parallel
+   - `agent: search strategy` — didn't check existing patterns before acting, reactive reads, redundant operations
 6. Rank findings by likely future token or time savings.
 7. Return only the 3-5 highest-leverage findings.
 8. Stop and ask the user which items to keep, merge, drop, or reprioritize.
@@ -50,3 +55,4 @@ Guardrails:
 - Do not produce generic "improve docs" advice.
 - Name the exact file or code area when possible.
 - If no meaningful wasted motion is visible, say so directly.
+- Analyze both user-facing interactions AND internal tool-use patterns. Do not bias toward one dimension.

--- a/docs/plans/2026-04-11-session-retro-commands-design.md
+++ b/docs/plans/2026-04-11-session-retro-commands-design.md
@@ -1,0 +1,163 @@
+# Session Retro Commands Design
+
+## Goal
+
+Add two Claude Code slash commands that improve future agent efficiency from the current session's evidence:
+
+- `/session-retro` analyzes the current live session and identifies repo-side changes that would likely have reduced wasted motion.
+- `/session-retro-apply` applies one user-confirmed change at a time.
+
+The design optimizes for repo-side leverage only. It does not ask the user to change how they prompt or collaborate.
+
+## Why This Exists
+
+Claude Code sessions often spend tokens on avoidable discovery:
+
+- repeated file searches
+- repeated code reading to infer one boundary or invariant
+- dead-end tool use
+- bouncing between files to reconstruct one concept
+- redundant verification caused by unclear instructions or weak code legibility
+
+The command family should turn that wasted motion into durable repo improvements such as better guidance, comments, examples, small refactors, or helper workflows.
+
+## Design Principles
+
+- Single responsibility at the command boundary
+- Analysis first, implementation only after explicit user confirmation
+- Evidence over hindsight
+- Repo-side fixes only
+- Smallest durable change preferred
+
+## Command 1: `/session-retro`
+
+### Responsibility
+
+Analyze the current live session only and produce a shortlist of repo-side improvements.
+
+### Inputs
+
+- The current live conversation context
+- Visible tool calls in the current session
+- Files discussed or touched in the current session
+
+### Constraints
+
+- No arguments
+- No implementation planning
+- No code edits
+- No advice about changing user prompting behavior
+- If earlier context is missing due to compaction, say so explicitly and lower confidence
+
+### Method
+
+1. Summarize the session goal.
+2. Reconstruct the path the agent took.
+3. Identify concrete friction points with evidence.
+4. For each friction point, answer: why did this detour make sense at the time?
+5. Map each friction point to exactly one primary repo-side fix type.
+6. Rank findings by expected future token or time savings.
+7. Stop at a shortlist and ask the user how to steer.
+
+### Fix Types
+
+- `instruction gap`: update `CLAUDE.md`, `AGENTS.md`, or command guidance
+- `comment gap`: add or improve code comments
+- `example gap`: add a local example, sample command, or focused doc
+- `boundary gap`: refactor files, modules, names, or structure to make intent easier to infer
+- `workflow gap`: add a helper script, shortcut, or verification command
+
+### Ranking Signals
+
+Prefer findings that:
+
+- repeated within the session
+- caused multiple downstream steps
+- blocked understanding of an important boundary
+- are likely to recur across future tasks
+
+### Output Shape
+
+- `Session goal`
+- `Path summary`
+- `Top findings`
+- `Shortlist to confirm`
+- `Question`
+
+Each finding must include:
+
+- `Observed friction`
+- `Why it happened`
+- `Recommended repo change`
+- `Why this should save tokens`
+- `Confidence`
+
+### Guardrails
+
+- Limit to 3-5 findings
+- Do not produce generic "improve docs" recommendations
+- Name the exact file or code area when possible
+- If no meaningful wasted motion is visible, say so directly
+
+## Command 2: `/session-retro-apply`
+
+### Responsibility
+
+Apply one user-confirmed retrospective change at a time.
+
+### Inputs
+
+- A free-form user instruction naming one specific confirmed change
+- Supporting context from the current conversation, including prior `/session-retro` analysis
+
+### Constraints
+
+- One change per invocation
+- If the request is ambiguous or bundles multiple changes, ask the user to narrow it
+- Do not silently implement adjacent findings
+
+### Method
+
+1. Restate the single requested change.
+2. Identify the exact repo surface involved.
+3. Make only that change.
+4. Verify the relevant outcome.
+5. Summarize what changed and any remaining follow-up.
+
+### Output Shape
+
+- `Requested change`
+- `Planned scope`
+- `Changes made`
+- `Verification`
+- `Remaining follow-up`
+
+### Guardrails
+
+- Prefer the smallest durable edit that satisfies the request
+- Do not reopen the whole retrospective
+- Do not implement multiple items from one vague instruction
+- Verify before claiming success
+
+## Example Flow
+
+1. User runs `/session-retro`
+2. Agent analyzes the current session and returns a shortlist
+3. User discusses, merges, drops, or reprioritizes findings
+4. User runs `/session-retro-apply` with one specific confirmed change
+5. Agent applies that one change and stops
+6. User repeats step 4 as needed
+
+## Non-Goals
+
+- Reading sessions other than the current live session
+- Persisting retrospective state outside the current conversation
+- Automatically batching multiple confirmed changes
+- Producing implementation plans from `/session-retro`
+
+## Recommended Implementation Shape
+
+- `.claude/commands/session-retro.md`
+- `.claude/commands/session-retro-apply.md`
+
+Each command should encode its boundary explicitly in the prompt so the interface, not just the wording, preserves SRP.


### PR DESCRIPTION
Adds `/session-retro` and `/session-retro-apply` Claude Code commands, along with the design doc that defines their boundaries. `/session-retro` analyzes the current live session for concrete sources of wasted motion, while `/session-retro-apply` narrows follow-up work to one user-confirmed problem or fix at a time. This gives future sessions a tighter path from observed friction to durable repo-side improvements, with the tradeoff that follow-up changes must stay intentionally narrow.