### PR TITLE
claude: refine command prompts for branch reviews and commits

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,15 +1,16 @@
 ---
-description: Group unstaged changes into 1–4 logical commits
+description: Group pending changes into 1–4 logical commits
+allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git status:*), Bash(git diff:*), Bash(git log:*), Read
 model: sonnet
 ---
 
 ## Context
 
 - Working tree status: !`git status --short`
+- Staged diff: !`git diff --cached`
 - Unstaged diff: !`git diff`
 - Recent commits: !`git log --oneline -5`
-- Current branch: !`git branch --show-current`
 
 ## Your task
 
-Review the unstaged changes and group them into 1 to 4 logical commits, each telling one coherent story. Stage and commit each group in turn, matching the style of recent commits. Leave any changes that don't fit a coherent group unstaged.
+Review all pending changes (staged and unstaged) and group them into 1 to 4 logical commits, each telling one coherent story. Stage and commit each group in turn, matching the style of recent commits. Leave any changes that don't fit a coherent group unstaged.

--- a/.claude/commands/walk-branch-changes.md
+++ b/.claude/commands/walk-branch-changes.md
@@ -12,12 +12,12 @@ Assume the reader has broad codebase familiarity; supply only the context needed
 
 Present one chunk at a time:
 
-- `Chunk N` with a one-line trace slice: `upstream event → changed operation → downstream effect`
-- A tight sequence of numbered steps, each one sentence shaped as `input/event → operation/transformation → emitted value/state effect`, with an inline `path:line` ref on the step it supports
+- Single chunk header line: `Chunk N — <concrete upstream event> → <concrete changed operation> → <concrete downstream effect>`. Substitute domain terms inline; do not emit the placeholder labels or repeat the pattern as a separate meta-line.
+- A tight sequence of numbered steps. Each step is exactly one transition shaped as `input/event → operation/transformation → emitted value/state effect`, with an inline `path:line` ref on the step it supports. If a single sentence would carry two transitions (e.g. predicate-match AND construction; validate AND emit), split into two steps. A brief cause clause attached to the transition's outcome is fine ("validates and passes — because X"); chaining a second transition behind an em-dash or semicolon is not.
 - Use the codebase's namespaced domain terms over generic wording; use exact symbol names only when they materially improve precision or editor lookup
-- Tag a step `(unchanged)` only when it exists purely to orient between changed steps; keep these rare and brief
+- When you must insert a bridge step purely to orient the reader between changed steps, tag it `(bridge)`. The originating-event step and the final state-effect step are bookends, not bridges, and carry no tag. Do not use any tag to mean "this code wasn't modified on the branch."
 
-Before writing each chunk, do two passes internally: first map the changed steps (with any minimal `(unchanged)` bridges needed for legibility), then rewrite the same chunk for display in clearer language without changing technical meaning, sequencing, project-specific terms, or `(unchanged)` labeling. Show only the second-pass result.
+Before writing each chunk, do two passes internally: first map the changed steps (with any minimal `(bridge)` steps needed for legibility), then rewrite the same chunk for display in clearer language without changing technical meaning, sequencing, project-specific terms, or `(bridge)` labeling. Show only the second-pass result.
 
 Trace the primary changed path; defer substantial alternate paths to later chunks. Include schemas or shared contracts as steps only when the branch changed them or they're needed to read a changed boundary.
 

--- a/.claude/commands/walk-branch-changes.md
+++ b/.claude/commands/walk-branch-changes.md
@@ -12,15 +12,13 @@ Assume the reader has broad codebase familiarity; supply only the context needed
 
 Present one chunk at a time:
 
-- Single chunk header line: `Chunk N — <concrete upstream event> → <concrete changed operation> → <concrete downstream effect>`. Substitute domain terms inline; do not emit the placeholder labels or repeat the pattern as a separate meta-line.
-- A tight sequence of numbered steps. Each step is exactly one transition shaped as `input/event → operation/transformation → emitted value/state effect`, with an inline `path:line` ref on the step it supports. If a single sentence would carry two transitions (e.g. predicate-match AND construction; validate AND emit), split into two steps. A brief cause clause attached to the transition's outcome is fine ("validates and passes — because X"); chaining a second transition behind an em-dash or semicolon is not.
-- Use the codebase's namespaced domain terms over generic wording; use exact symbol names only when they materially improve precision or editor lookup
-- When you must insert a bridge step purely to orient the reader between changed steps, tag it `(bridge)`. The originating-event step and the final state-effect step are bookends, not bridges, and carry no tag. Do not use any tag to mean "this code wasn't modified on the branch."
-
-Before writing each chunk, do two passes internally: first map the changed steps (with any minimal `(bridge)` steps needed for legibility), then rewrite the same chunk for display in clearer language without changing technical meaning, sequencing, project-specific terms, or `(bridge)` labeling. Show only the second-pass result.
+- Header line: `Chunk N — <concrete upstream event> → <concrete changed operation> → <concrete downstream effect>`. Substitute domain terms inline; do not emit the placeholder labels.
+- Body: short prose paragraphs, one per causal arc. Open the chunk with the originating event (inbound trigger, or first changed boundary for internal-only changes). Close with the downstream effect (state change, persisted value, DOM update). Each paragraph traces a single causal arc through the changed code.
+- Cite `path:line` inline only on changed lines. Unchanged glue carries no citation — that absence is the signal. Do not pool refs at end of paragraph or chunk.
+- Use the codebase's namespaced domain terms over generic wording; use exact symbol names only when they materially improve precision or editor lookup.
 
 Trace the primary changed path; defer substantial alternate paths to later chunks. Include schemas or shared contracts as steps only when the branch changed them or they're needed to read a changed boundary.
 
 Stop after each chunk and wait. If I ask follow-ups, answer inline and resume from the same place.
 
-Avoid: file-by-file narration when a trace slice is clearer, code snippets, rationale or critique unless asked, pooled refs at the end of a chunk, and dropping transitions or renaming domain terms while simplifying.
+Avoid: file-by-file narration when a trace slice is clearer; code snippets; rationale or critique unless asked; soft-renaming domain terms for prose flow; stage-managing transitions ("Now…", "Next…", "Moving on…"); padding sentences that don't carry a transition; over-summarising in a way that elides a changed step.

--- a/.claude/commands/walk-branch-changes.md
+++ b/.claude/commands/walk-branch-changes.md
@@ -6,17 +6,21 @@ model: sonnet
 
 Walk the diff in execution order so I can place the changes in the domain workflow without re-tracing the subsystem.
 
-Diff target: $ARGUMENTS (if empty, current branch vs `main`).
+Diff target: $ARGUMENTS (default: current branch vs `main`).
+
+Assume the reader has broad codebase familiarity; supply only the context needed to place the diff. Lead with branch delta before implementation detail. Start chunk selection from the changed behavior, not the subsystem's public API; for internal-only changes, start from the first changed boundary.
 
 Present one chunk at a time:
 
 - `Chunk N` with a one-line trace slice: `upstream event → changed operation → downstream effect`
-- A tight sequence of numbered steps, each one sentence describing a concrete transition, with an inline `path:line` ref on the step it supports
-- Use the codebase's domain terms over generic wording
+- A tight sequence of numbered steps, each one sentence shaped as `input/event → operation/transformation → emitted value/state effect`, with an inline `path:line` ref on the step it supports
+- Use the codebase's namespaced domain terms over generic wording; use exact symbol names only when they materially improve precision or editor lookup
 - Tag a step `(unchanged)` only when it exists purely to orient between changed steps; keep these rare and brief
+
+Before writing each chunk, do two passes internally: first map the changed steps (with any minimal `(unchanged)` bridges needed for legibility), then rewrite the same chunk for display in clearer language without changing technical meaning, sequencing, project-specific terms, or `(unchanged)` labeling. Show only the second-pass result.
+
+Trace the primary changed path; defer substantial alternate paths to later chunks. Include schemas or shared contracts as steps only when the branch changed them or they're needed to read a changed boundary.
 
 Stop after each chunk and wait. If I ask follow-ups, answer inline and resume from the same place.
 
-Start from the changed behavior, not the subsystem's public API. If changes are internal-only, start from the first changed boundary. Trace the primary changed path; defer substantial alternate paths to later chunks. Include schemas or shared contracts as steps only when the branch changed them or they're needed to read a changed boundary.
-
-Avoid: file-by-file narration, code snippets, rationale/critique unless asked, pooled refs at the end.
+Avoid: file-by-file narration when a trace slice is clearer, code snippets, rationale or critique unless asked, pooled refs at the end of a chunk, and dropping transitions or renaming domain terms while simplifying.


### PR DESCRIPTION
Updates the Claude /walk-branch-changes prompt to produce chunked, behavior-led branch walkthroughs with tighter citation rules and less file-by-file narration. Also updates /commit so it considers staged and unstaged changes, includes the staged diff in context, and declares the git/read tools it needs. This keeps both commands aligned with the way they are actually used during review and commit prep.