### PR TITLE
codex: align skills with Claude commands and add agent manifests

### DIFF
--- a/.claude/skills/strategic-artifact/build-lineage-map.py
+++ b/.claude/skills/strategic-artifact/build-lineage-map.py
@@ -28,7 +28,11 @@ BACKTICKED = re.compile(r"`([^`]+)`")
 def parse_edges(root, excluded):
     """child rel-path -> [parent rel-path, ...], in declaration order."""
     edges = {}
-    for md in sorted(root.rglob("*.md")):
+    artifacts = sorted(
+        [*root.rglob("*.md"), *root.rglob("*.html")],
+        key=lambda p: p.relative_to(root).as_posix(),
+    )
+    for md in artifacts:
         rel = md.relative_to(root)
         if md.name == "README.md" or excluded & set(rel.parts[:-1]):
             continue

--- a/.codex/skills/create-commit/SKILL.md
+++ b/.codex/skills/create-commit/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: create-commit
-description: Use when the user wants Codex to create a git commit from already-staged changes without staging anything else, especially when the message should match recent repo history and stay concise.
+description: Use when the user wants Codex to organize and commit pending Git changes, including mixed staged, unstaged, or relevant untracked work.
 ---
 
-# Create Commit
+# Create Commits
 
-Create a commit from the current staged changes only.
+Review all pending changes and create one to four logical commits, each telling one coherent story.
 
 ## Inputs
 
@@ -14,24 +14,30 @@ Create a commit from the current staged changes only.
 
 ## Workflow
 
-1. Inspect only the staged diff, the current branch, and a few recent commits:
+1. Inspect the complete pending state and recent commit style:
+   - `git status --short`
    - `git diff --cached`
-   - `git branch --show-current`
-   - `git log --oneline -3`
-2. If nothing is staged, stop and say so. Do not guess.
-3. Infer the commit intent from the staged changes only. Ignore unstaged and untracked files.
-4. Draft a concise Conventional Commit title that matches the repo's recent style.
-5. Add a body only when it captures intent or a key decision that belongs in history.
-6. Create the commit. Do not run `git add`.
+   - `git diff`
+   - `git log --oneline -5`
+   Use the status output to identify untracked files, then inspect the contents of untracked files that may belong to the pending work.
+2. If there are no staged changes, unstaged changes, or relevant untracked files, stop and report that there is nothing to commit.
+3. Partition the pending work into one to four coherent groups. Treat the current staging state as input, not as a commit boundary: related staged, unstaged, and untracked changes belong in the same group. Leave any change that does not fit a coherent group unstaged. Never combine unrelated work merely to stay within the four-commit limit.
+4. Prepare and commit each group in turn:
+   - If pre-staged changes span groups, unstage them only as needed without changing working-tree contents.
+   - Stage only the paths or hunks in the current group. Use patch staging when one file contains changes for different groups.
+   - Review `git diff --cached` and `git status --short` to confirm that the index contains exactly the current group.
+   - Write a concise message matching the style of the five recent commits. Use Conventional Commits only when that matches the repository's recent style.
+   - Commit the group, then repeat for the next group, up to four commits.
+5. Re-run `git status --short` when finished to identify work intentionally left unstaged.
 
 ## Guardrails
 
-- Never stage files.
-- Never include unstaged or unrelated work.
+- Never discard or overwrite working-tree changes while reorganizing the index.
+- Do not broadly stage all changes when the pending work contains unrelated files.
+- Do not amend an existing commit unless the user explicitly asks.
 - Never mention conversation context that is not reflected in the staged diff.
-- Keep the wording minimal and direct.
-- If commit creation fails, report the failure and stop.
+- If staging or commit creation fails, stop immediately, report the failure and current status, and do not continue with later groups.
 
 ## Final Response
 
-Return the commit hash and final commit subject. If a body was used, summarize it briefly instead of reprinting a long message.
+List each created commit by short hash and subject. Briefly report any changes left unstaged or untracked; if no commits were needed, say so directly.

--- a/.codex/skills/create-commit/agents/openai.yaml
+++ b/.codex/skills/create-commit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Create Logical Commits"
+  short_description: "Group pending changes into logical commits"
+  default_prompt: "Use $create-commit to review all pending changes and create up to four coherent commits."

--- a/.codex/skills/create-draft-pr/SKILL.md
+++ b/.codex/skills/create-draft-pr/SKILL.md
@@ -1,54 +1,68 @@
 ---
 name: create-draft-pr
-description: Use when the user wants Codex to draft a pull request from the current branch, especially when the base branch must be inferred from free-form input or optional planning context may help shape the PR summary.
+description: Use when the user asks Codex to create a draft pull request from the current Git branch, with or without an explicit base branch.
 ---
 
 # Create Draft PR
 
-Draft concise PR text for the current branch and, after confirmation, create the draft PR.
+Create and open a concise draft PR for the current branch. Invocation authorizes push, creation, and view; do not ask for confirmation.
 
-## Inputs
+## Resolve the base
 
-- Accept a single free-form argument string.
-- Infer three optional values from that string:
-  - `base_branch`
-  - `plan_file`
-  - `phase_pointer`
+- Use the optional invocation argument exactly as the base branch.
+- If it is omitted, run `git symbolic-ref refs/remotes/origin/HEAD`, strip the `refs/remotes/origin/` prefix from the result, and use that short branch name.
+- If symbolic-ref resolution fails or returns no branch, fall back to `main`.
 
-Treat `plan_file` and `phase_pointer` as internal context only. Never mention them in the PR title or body.
+## Inspect the branch
 
-## Parsing Rules
+Run these commands before drafting:
 
-- Prefer explicit forms such as `base <branch>`, `into <branch>`, `against <branch>`, or `to <branch>`.
-- Treat existing branch names as base-branch candidates.
-- Treat existing `.md`, `.markdown`, or `.txt` paths as plan-file candidates.
-- Treat text after `phase`, `focus`, `for`, or trailing quoted text as a possible phase pointer.
-- If there is no clear base branch, default to `main`.
-- If multiple plausible base branches or plan files remain, treat the request as ambiguous.
+```bash
+git branch --show-current
+git status --short
+git log --oneline -20
+git log <base>..HEAD --oneline
+git diff <base>...HEAD --stat
+gh pr list --state merged --limit 10
+```
 
-## Workflow
+Replace `<base>` with the resolved branch and safely quote it in the base-relative Git commands.
 
-1. Inspect the current branch, branch status, commit history, and diff against the inferred base branch.
-2. If practical, inspect recent merged PR titles to match repository conventions. Otherwise infer style from recent commits.
-3. Generate:
-   - a concise PR title that states the technical change and purpose
-   - a concise 2-4 sentence PR body covering what changed, why it matters, and at most one key tradeoff
-4. If parsing is ambiguous, switch to draft-only mode and stop automation.
-5. Otherwise, present the prepared title, body, and inferred base branch, then ask for confirmation before any network action.
-6. Only after confirmation:
-   - push the branch if needed
-   - create a draft PR with `gh pr create --draft`
-   - open it with `gh pr view --web`
-7. If any `gh` step fails, fall back to draft-only mode and return the prepared text plus the exact command to run manually.
+Match recent merged PR title style. If the list is empty, match recent branch commit style. If `gh pr list` fails, use commit style to prepare the text, then follow the failure contract without push/create/view.
 
-## Guardrails
+## Prepare the PR
 
-- Be direct. No filler.
-- Keep planning context private.
-- Do not push or create a PR before explicit confirmation.
-- If ambiguity remains, prefer draft-only mode over guessing.
+Produce:
 
-## Final Response
+1. A concise technical title that states the change and its purpose, matching the selected repository style.
+2. A body of exactly 2–5 short Markdown bullets. Each is simple, direct, and standalone. Together they cover what changed, why it matters, and at most one key tradeoff. Use no headings or prose paragraphs.
 
-- If PR creation succeeds: return the title, body, base branch, and PR URL.
-- If draft-only mode is used: say why, then return the title, body, and exact manual `gh pr create --draft ...` command.
+Prepare an exact, shell-safe manual command containing the resolved values:
+
+```bash
+gh pr create --draft --base <base> --title <title> --body <body>
+```
+
+Shell-quote each dynamic value as one argument. For Bash-compatible quoting, render the command with `printf '%q'` for the base, title, and multiline body.
+
+## Create and open the PR
+
+Proceed without another confirmation turn, in this order:
+
+1. If the branch has no upstream or has local commits not present upstream, run `git push -u origin HEAD`.
+2. Run `gh pr create --draft --base <base> --title <title> --body <body>` with each resolved value passed as one safely quoted argument.
+3. Run `gh pr view --web`.
+
+Do not run create before a necessary push, and do not run view before create succeeds.
+
+## Handle `gh` failures
+
+Every failed `gh` operation uses the same result contract:
+
+- If `gh pr list --state merged --limit 10` fails, stop before push/create/view.
+- If `gh pr create --draft` fails, stop before view.
+- If `gh pr view --web` fails, stop after reporting the view failure.
+
+Lead with the technical result. Return the prepared title, the 2–5-bullet body, the resolved base, and the exact safely shell-quoted `gh pr create --draft` command for manual execution. Be direct.
+
+On success, lead with the technical result and report that the draft PR was created and opened, including its URL when available.

--- a/.codex/skills/create-draft-pr/agents/openai.yaml
+++ b/.codex/skills/create-draft-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Create Draft PR"
+  short_description: "Create and open a concise draft pull request"
+  default_prompt: "Use $create-draft-pr to create and open a concise draft pull request for the current branch."

--- a/.codex/skills/frame-minutes/SKILL.md
+++ b/.codex/skills/frame-minutes/SKILL.md
@@ -1,43 +1,64 @@
 ---
 name: frame-minutes
-description: "Use when a user provides a pre-cleaned transcript (Speaker: utterance format) and wants structured meeting minutes using bottom-up fact extraction -- especially for co-founder chats, customer discovery, or advisor calls where alignment and shared context matter alongside decisions."
+description: "Use when a user provides a pre-cleaned Speaker: utterance dialogue file and wants structured meeting minutes, especially for co-founder chats, customer discovery, or advisor calls; do not use for raw call, meeting, or VTT transcripts."
 ---
 
 # Frame Minutes
 
-Turn pre-cleaned transcript text into structured minutes using bottom-up fact extraction. Themes emerge from where facts cluster, not from top-down categorization.
+Turn a pre-cleaned `Speaker: utterance` dialogue file into structured minutes through bottom-up fact extraction. Themes emerge from where facts cluster, not from top-down categorization.
 
-## Inputs
+**Defining value:** distill by cutting, not rewriting. What remains after compression must be the speaker's own phrasing, style, and rhythm. These minutes should sound like the speakers — not like a secretary.
 
-- Require pre-cleaned transcript text in `Speaker: utterance` format (output of `rewrite-call-transcript`).
-- Preserve speaker names from the transcript — attribute facts, decisions, and action items to named individuals.
-- Accept optional background context from the user.
+## Three-turn contract
 
-## Function Labels
+Advance exactly one user-visible stage per assistant turn:
 
-Every extracted fact gets one label:
+1. Initial request: resolve the output path, read the dialogue with line numbers, show the theme map, then stop and wait.
+2. First user reply: incorporate the user's theme feedback, show the outline, then stop and wait.
+3. Second user reply: incorporate the user's outline feedback, write the final minutes, and return only a short path confirmation.
 
-| Label | Captures |
-|-------|----------|
-| **Decision** | A choice was made or commitment given. Action items surface through metadata (owner + deadline) on Decision labels — a decision with an owner and date is an action item. |
-| **Alignment** | Shared understanding established or confirmed between participants. |
-| **Insight** | New understanding surfaced during discussion. |
-| **Context** | Background information relevant to other facts. |
+Do not combine stages, even when there are no ambiguity questions or the user says to proceed automatically. Keep the resolved output path, numbered dialogue, extracted facts, scores, labels, and user feedback in working context across all three turns.
 
-## Pipeline
+## Step 1 — Resolve the output path
 
-### Turn 1: Extract & Score
+Resolve the minutes output path internally before reading the dialogue. Use read-only shell inspection such as `ls` on the input file's parent directory; do not delegate this work or show it to the user.
 
-Read the full transcript. Internally:
-1. Extract atomic facts as `(distilled utterance, speaker, context)` tuples — distill by cutting, not rewriting. Remove filler, false starts, and redundancy, but keep the speaker's phrasing and style. The result should sound like them, just shorter.
-2. Label each fact: Decision / Alignment / Insight / Context
-3. Score relevance 1–10 relative to this transcript (decisions tend toward 9–10, supporting context toward 4–6)
-4. Cluster facts by topic proximity — themes emerge bottom-up from where facts cluster
-5. Retain ~40% of facts (drop lowest relevance scores)
+- Identify the input's trailing suffix segments (for example, `.dialogue.txt`).
+- Look for sibling files that share the input's stem but use a `minutes`-containing suffix (for example, `.minutes.md` or `.minutes.txt`).
+- If a sibling-attested minutes suffix exists, build the output path by replacing the input's suffix with that minutes suffix. If multiple variants exist, choose the most common one.
+- If no informative sibling pattern exists, strip the input's extension or extensions and append `.minutes.md`.
 
-**Output to user:** Compact theme map (aim for 3–7 themes; prefer fewer, broader themes):
+Hold the one resolved output path in working context. Use it verbatim in Turn 3 and do not recompute it. Do not create, truncate, or otherwise modify the output file during Turn 1.
 
+## Step 2 — Read the dialogue
+
+Read the entire dialogue once with stable, one-based line numbers, using a read-only command such as:
+
+```bash
+nl -ba -- "<dialogue-file>"
 ```
+
+Keep the numbered dialogue in context for the rest of the run. Fidelity to each speaker's phrasing matters more than context economy because the input is already distilled.
+
+Preserve speaker names from the dialogue. Attribute facts, decisions, and action items to named individuals. Accept explicit background context supplied by the user, but ground all content in the dialogue or that user-supplied context.
+
+## Step 3 — Turn 1: Extract & Score → Theme Map
+
+**Do internally; do not show this work unless the user asks for raw facts:**
+
+1. Extract atomic facts as `(distilled utterance, speaker, line, context)` tuples. Distill by cutting, not rewriting: remove filler, false starts, and redundancy while keeping the speaker's phrasing and style. `line` is the numbered dialogue line where the fact lands. Capture line numbers now for Turn 3 citations.
+2. Label each fact:
+   - **Decision** — a choice was made or commitment given. Action items surface through inline owner-and-deadline metadata on Decision labels; a decision with an owner and date is an action item.
+   - **Alignment** — shared understanding established or confirmed between participants.
+   - **Insight** — new understanding surfaced during discussion.
+   - **Context** — background information relevant to other facts.
+3. Score relevance from 1–10 relative to this dialogue. Decisions tend toward 9–10; supporting context tends toward 4–6.
+4. Cluster facts by topic proximity. Themes emerge bottom-up from where facts cluster.
+5. Retain about 40% of facts by dropping the lowest relevance scores.
+
+Show a compact theme map. Aim for 3–7 themes and prefer fewer, broader themes:
+
+```markdown
 1. **Auth migration path** [3 decisions, 1 alignment] — JWT removes the last mobile blocker
 2. **Series A timing** [2 alignments, 1 insight] — Both leaning toward Q3 if ARR hits 800k
 3. **Customer onboarding friction** [1 insight, 3 context] — Drop-off at step 3 is 40%
@@ -45,30 +66,34 @@ Read the full transcript. Internally:
 Excluded: weekend plans, restaurant recommendations
 ```
 
-Format: `N. **Theme name** [label counts] — key signal in ≤12 words`
+Use `N. **Theme name** [label counts] — key signal in ≤12 words`. Make the key signal informative enough that the user can answer any question without reopening the dialogue.
 
-Include an *"Excluded: [brief list]"* line for topics dropped (passing mentions, off-topic). When borderline, include as a low-relevance theme rather than excluding.
+Include an `Excluded:` line for dropped passing mentions and off-topic material. When borderline, include the material as a low-relevance theme rather than excluding it.
 
-**Debug affordance:** If the user asks to see raw facts, show the scored fact list before the theme map.
+If the user asks to see raw facts, show the scored fact list before the theme map and remain on Turn 1.
 
-**Questions (max 2):** Multiple-choice, 2–4 described options each, targeting genuine ambiguity the LLM cannot confidently resolve. User should be able to answer by reading the theme map, without returning to the transcript. Default path: "looks good" or equivalent proceeds as-is.
+Ask zero, one, or two multiple-choice questions only for genuine ambiguity that cannot be resolved confidently. Give 2–4 described options per question. The default path is `looks good` or equivalent. Do not invent a question merely to fill the slot.
 
-Example question format:
+Example:
+
 > *Themes 2 ('Series A timing') and 3 ('Customer onboarding') both touch growth. How should I handle them?*
-> - **Keep separate** — Distinct enough that separate sections serve reference better
-> - **Merge into 'Growth strategy'** — The connection between them is the interesting part
-> - **Merge, lead with onboarding** — The customer data is more actionable than the timing discussion
+> - **Keep separate** — Distinct enough that separate sections serve reference better.
+> - **Merge into 'Growth strategy'** — The connection between them is the interesting part.
+> - **Merge, lead with onboarding** — The customer data is more actionable than the timing discussion.
 
-### Turn 2: Organize
+Stop after the theme map and any questions. Wait for the user's reply before Turn 2.
+
+## Step 4 — Turn 2: Organize
 
 Using the validated theme map:
-1. Order themes by combined fact relevance
-2. Highest-scoring facts + all Decisions/Alignments → major outline points
-3. Remaining retained facts → supporting detail nested under major points
 
-**Output to user:** Structured outline skeleton:
+1. Order themes by combined fact relevance.
+2. Promote the highest-scoring facts and every Decision and Alignment to major outline points.
+3. Nest the remaining retained facts as supporting detail beneath major points.
 
-```
+Show a structured outline skeleton:
+
+```markdown
 ## Auth migration path [decision]
 - JWT is the move — kills the last mobile blocker (Paul, by Mar 22)
 - "We're done with server-side tokens" — deprecated, 2-week window with fallback baked in
@@ -78,56 +103,63 @@ Using the validated theme map:
   - "Not worth the distraction" — intros paused until milestone hit
 ```
 
-**Questions (max 2):** Multiple-choice, targeting ambiguity. User should be able to answer by reading the outline, without returning to the transcript. Default path proceeds if user doesn't engage.
+Ask zero, one, or two multiple-choice questions only for genuine ambiguity in framing. Give enough detail in the outline and in 2–4 described options that the user need not reopen the dialogue. The default proceeds.
 
-Example question format:
+Example:
+
 > *'Pricing model' came up three times but with mixed signals. How should I frame it?*
-> - **Decision reached** — The last exchange settled it; earlier hesitation is just context
-> - **Still exploring** — No clear convergence; mark as open with options discussed
-> - **Alignment without decision** — You both see the problem the same way but haven't picked an approach
+> - **Decision reached** — The last exchange settled it; earlier hesitation is context.
+> - **Still exploring** — No clear convergence; mark it open with the options discussed.
+> - **Alignment without decision** — The problem is shared, but no approach was chosen.
 
-### Turn 3: Write & Tighten
+Stop after the outline and any questions. Wait for the user's reply before Turn 3.
 
-No questions. Final output:
-1. Render structured outline with:
-   - Theme headings ordered by significance
-   - Nested bullets with inline function labels: `[decision]`, `[alignment]`, `[insight]`, `[context]`
-   - Metadata where applicable: speakers, owners, dates
-2. Shortening pass: compress each point to the key idea
-   - Preserve: decisions, commitments, owners, dates, alignment markers, explicit uncertainty
-   - Remove: filler, redundancy, over-explanation
-   - Distill by cutting, not rewriting — what remains after compression should be the speaker's own phrasing, their style, rhythm, and word choices. Don't normalize into a "minutes voice."
+## Step 5 — Turn 3: Write, Tighten, and Persist
 
-Example final output:
+Ask no questions. Render the final minutes with this exact contract:
 
-```
+- Order `##` theme headings by significance. Put no type tag on a theme heading.
+- Use optional plain, unbolded subsection labels inside a theme when discussion clusters into sub-threads. A subsection label is a standalone line, not a bullet.
+- Begin every bullet with exactly one function label: `[decision]`, `[alignment]`, `[insight]`, or `[context]`.
+- Put speaker attribution immediately after the function label when one speaker drives the fact (`- [decision] Paul: …`). Omit speaker attribution when the fact is jointly held.
+- Weave exact direct quotes from the dialogue wherever the original wording carries the force. Quote the speaker's exact wording for the spicy bits; paraphrase only connective tissue.
+- End every bullet with its captured dialogue line number as `:NNN`. Use the actual bare line number and do not repeat the dialogue filename.
+- Keep owners and dates inline, never in a separate metadata block.
+
+Apply one shortening pass to compress each point to the key idea:
+
+- Preserve decisions, commitments, owners, dates, alignment markers, and explicit uncertainty.
+- Remove filler, redundancy, and over-explanation.
+- Distill by cutting, not rewriting. Keep the speakers' phrasing, style, rhythm, and word choices; do not normalize into a minutes voice.
+
+Example final shape:
+
+```markdown
 ## Auth migration path
 
-- [decision] JWT is the move — kills the last mobile blocker (Paul, by Mar 22)
-- [decision] "Done with server-side tokens" — deprecated; 2-week migration window with fallback
-- [alignment] Both "fine with the risk at this scale"
+JWT cutover
+- [decision] Paul: JWT is "the move" — kills the last mobile blocker. Target Mar 22. :225
+- [decision] "Done with server-side tokens" — deprecated; 2-week window with fallback. :243
+- [alignment] Both "fine with the risk at this scale." :251
 
 ## Series A timing
 
-- [alignment] "Pretty convinced" Q3 if ARR hits 800k — shared threshold
-- [decision] "Not worth the distraction" — intros paused until milestone hit
-- [insight] Board seat expectations may "vary a lot" between target leads — needs research
+- [alignment] Both "pretty convinced" Q3 if ARR hits 800k. :310
+- [decision] "Not worth the distraction" — intros paused until milestone hit. :322
+- [insight] Board seat expectations "vary a lot" between target leads — needs research. :340
 ```
 
-## Quality Rules
+Write the content to the output path resolved in Step 1 using `apply_patch`. If the resolved output file already exists, overwrite its content. Do not write any other meeting file.
 
-- Thematic organization, not chronological
-- Order themes by significance
-- Consolidate scattered discussion of the same topic
-- Mention each concept once in its best location
-- Keep uncertainty explicit — never upgrade "we should think about" to a decision
-- Never add information not grounded in the transcript
-- Alignment and context are first-class, not supporting detail for decisions
-- Distill by cutting, not rewriting — the minutes should sound like the speakers, not like a secretary. Preserve each speaker's phrasing, style, and voice. Remove filler and redundancy; never normalize language.
+After the write succeeds, return exactly one short line confirming the output path and nothing else.
 
-## Baked-in Reader Assumptions
+## Quality rules
 
-- Reader is the meeting participant
-- Primary use: future reference and pattern recognition
-- Values alignment and shared context alongside decisions
-- Needs facts well-labeled for later search and dot-connecting
+- Organize thematically, not chronologically.
+- Order themes by significance.
+- Consolidate scattered discussion of the same topic.
+- Mention each concept once in its best location.
+- Keep uncertainty explicit. Never upgrade `we should think about`, `we could`, `maybe`, or another suggestion into a decision.
+- Never add information not grounded in the dialogue or explicit user-supplied context.
+- Treat Alignment and Context as first-class facts, not merely supporting detail for Decisions.
+- Serve a meeting participant using the minutes for future reference and pattern recognition; preserve alignment and shared context alongside decisions, and label facts for later search.

--- a/.codex/skills/frame-minutes/agents/openai.yaml
+++ b/.codex/skills/frame-minutes/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Frame Minutes"
-  short_description: "Bottom-up fact extraction into structured meeting minutes"
-  default_prompt: "Use $frame-minutes to process this transcript into structured minutes using bottom-up fact extraction."
+  short_description: "Frame cleaned dialogue into structured minutes"
+  default_prompt: "Use $frame-minutes on this pre-cleaned Speaker: utterance dialogue file."

--- a/.codex/skills/rewrite-call-transcript/SKILL.md
+++ b/.codex/skills/rewrite-call-transcript/SKILL.md
@@ -1,80 +1,135 @@
 ---
 name: rewrite-call-transcript
-description: Use when a user provides a call, meeting, interview, podcast, or other conversation transcript that needs to be rewritten into clean speaker-by-speaker dialogue, especially when the transcript is long, noisy, speaker labels are messy, or ASR errors need conservative repair.
+description: Use when a user wants a noisy call, meeting, interview, podcast, or other conversation transcript file rewritten into clean speaker-by-speaker dialogue, especially when speaker labels are messy or ASR errors need conservative repair.
 ---
 
 # Rewrite Call Transcript
 
-Turn noisy transcript text into readable dialogue without adding meaning that is not present in the source.
+Rewrite a transcript file into readable speaker-by-speaker dialogue without adding meaning that is not present in the source. Keep the raw transcript out of the controller context.
 
-## Inputs
+## Canonical input and roster gate
 
-- Require the raw transcript text.
-- Expect a speaker roster before the transcript, with each speaker described in 2-3 words.
-- Treat the speaker roster as primary attribution context.
-- Use the roster heavily to resolve vague labels, role references, and likely speaker continuity.
-- Reuse raw speaker labels only when they help map a turn to the roster.
-- If the roster is missing or incomplete, stay conservative: do not invent names.
+Accept a transcript file path as the canonical input.
 
-## Workflow
+On the first turn, before inspecting the path, reading any transcript content, resolving an output path, or spawning a subagent, ask the user to paste a speaker roster with one speaker per line and a 2–3 word description, for example:
 
-Use a controller workflow with sub-agents so the main context holds conversation structure, not every raw utterance. The controller must not load the full raw transcript into its own context.
+`Alice — founder, technical`
 
-1. Read the speaker roster and the user's task framing only. Do not load the full raw transcript into the controller context.
-2. Dispatch a mapper sub-agent to read the full raw transcript and return a compact `conversation_map` with:
-   - likely speakers and source labels
-   - topic shifts and natural chunk boundaries
-   - ambiguity hotspots such as cross-talk, broken sentences, or unclear terms
-3. Create and maintain a `continuity_ledger` containing canonical speaker names, stable technical terms, unresolved mappings, and any other consistency decisions.
-4. Split the transcript at natural boundaries with a small overlap. Short transcripts can stay as one chunk.
-5. Dispatch a cleaner sub-agent for each chunk with the chunk text, the relevant `conversation_map` excerpt, the speaker roster, and the current `continuity_ledger`. Each cleaner should return:
-   - `cleaned_chunk`: rewritten dialogue for that span
-   - `open_questions`: anything still ambiguous after best-effort cleanup
-6. Only when a chunk contains a real ambiguity hotspot, dispatch a challenger sub-agent for that span and ask for 2 conservative `hotspot_variants`. Use this for uncertainty, not for stylistic experimentation.
-7. The controller chooses the most defensible variant, updates the `continuity_ledger`, harmonizes overlaps and naming, and assembles the final transcript.
-8. When seams, speaker continuity, or hotspot choices remain uncertain, dispatch a follow-up sub-agent to inspect only the relevant raw span and return a minimal excerpt or resolution note. The controller should not reopen the raw transcript itself.
+End the turn immediately after asking. Do not process anything until the user replies. Treat the returned roster as the primary attribution context for vague labels, role references, and likely speaker continuity. If the roster is missing or incomplete, stay conservative and never invent names.
 
-## Controller Rules
+## Controller workflow
 
-- Do not paste, quote, or load the entire raw transcript into the controller context.
-- Keep the controller working set limited to the speaker roster, `conversation_map`, `continuity_ledger`, rewritten chunks, and small targeted raw excerpts returned by sub-agents.
-- If more raw evidence is needed, ask a sub-agent to inspect the specific span and return only the minimum needed to decide.
-- Use sub-agents for transcript inspection. Use the controller for coordination, consistency, and final assembly.
+Use fresh-context Codex subagents for raw-file inspection. The controller coordinates them but never reads the full raw transcript.
 
-## Cleaner Rules
+### 1. Resolve the output path
 
-- Keep speaker order and conversational flow intact.
-- Format each turn as `Speaker: utterance` or `Speaker [uncertain]: utterance`.
-- Remove silence hallucinations and filler loops.
-- Remove most repeated `yeah` or similar filler insertions unless they answer a yes/no question, confirm something explicitly, or carry real meaning.
-- Remove filler, false starts, stutters, and repetitions only when meaning does not change.
-- Fix proper nouns, numbers, contractions, grammar, agreement, and technical terms only when nearby transcript context, repeated usage, or the speaker roster strongly supports the repair.
-- Rewrite fragments only enough to recover the intended meaning.
-- Preserve all concepts, claims, decisions, numbers, and technical details present in the source.
-- Do not add new information, interpretation, speaker intent, or implied context that is not grounded in the transcript.
-- Do not summarize, combine turns, or smooth wording in ways that introduce new concepts.
-- When a word or segment cannot be recovered confidently after best-effort cleanup, write `[unclear]`.
-- Use `Speaker: utterance` when the transcript and roster support the attribution confidently.
-- Use `Speaker [uncertain]: utterance` when a named speaker is plausible but not certain.
-- If no named attribution is defensible, preserve the source label and mark it `[uncertain]` when that helps, otherwise use `Unknown Speaker [uncertain]: utterance`.
+After the roster reply, spawn a fresh-context path resolver. Give it the input transcript path and the resolution instructions only; do not give it transcript content, the roster, or controller history. Require it to:
 
-## Output
+- List the input file's parent directory.
+- Identify the input's trailing suffix segments, such as `.transcript.vtt`.
+- Find sibling files that share the input's stem and have a `dialogue`-containing suffix, such as `.dialogue.txt` or `.dialogue.md`.
+- If a sibling convention exists, replace the input suffix with that sibling-attested dialogue suffix. If several variants exist, use the most common.
+- Otherwise, strip the input's extension or extensions and append `.dialogue.txt`.
 
-Return only the rewritten transcript inside `<rewritten_transcript>` tags.
+Require exactly one returned line containing the resolved output path, with no listing or rationale. Keep that path verbatim for the write step.
 
-Internal workflow artifacts such as `conversation_map`, `continuity_ledger`, `cleaned_chunk`, and `hotspot_variants` are for coordination only. Do not expose them in the final answer.
+### 2. Map the conversation
 
-If you made any significant interpretation, non-obvious speaker mapping, or material repair that could affect how the transcript is read, add a `<notes>` block after the transcript. Omit `<notes>` when there is nothing material to flag.
+Spawn a fresh-context mapper with the transcript file path and roster. It may read the full file. Require only a compact `conversation_map` containing:
 
-Use this exact shape:
+- likely speakers and their source labels
+- the physical `source_line_count`
+- topic shifts and natural chunk boundaries as exact inclusive line ranges
+- ambiguity hotspots such as cross-talk, broken sentences, and unclear terms
+
+Require the mapper to number physical file lines with `nl -ba` or an equivalent line-numbered read. Its chunk ranges must be contiguous, non-overlapping, and collectively cover lines 1 through `source_line_count`; metadata or blank lines may remain inside a range. The mapper must not return or quote the full transcript. Validate range coverage numerically in the controller and return the map for correction before cleaning if a line is missing or duplicated.
+
+### 3. Maintain continuity
+
+Keep a controller-side `continuity_ledger` with canonical speaker names, stable technical terms, unresolved mappings, and consistency decisions. Update it as cleaners return.
+
+### 4. Clean mapped chunks
+
+For every mapped chunk, spawn a fresh-context cleaner. A short transcript may remain one chunk. Give each cleaner:
+
+- the transcript file path
+- the chunk's exact inclusive line range
+- a small, explicitly labeled overlap range from the preceding chunk's tail when one exists
+- the speaker roster
+- the relevant `conversation_map` excerpt
+- the current `continuity_ledger`
+
+Give paths and ranges, not raw chunk text copied through the controller. Require the cleaner to read only its assigned range and overlap and return only:
+
+- `cleaned_chunk`: rewritten dialogue for the assigned span
+- `open_questions`: ambiguities that remain after best-effort cleanup
+
+Use the overlap only to preserve repeated names, technical terms, speaker continuity, and sentence flow. Harmonize and de-duplicate overlaps during assembly.
+
+### 5. Challenge only real hotspots
+
+Only for a chunk the mapper marked as a genuine ambiguity hotspot, spawn a fresh-context challenger with the path, exact hotspot line range, roster, relevant map excerpt, and ledger. Require exactly two conservative `hotspot_variants`. Use this to examine uncertainty, not to experiment with style. Choose the most defensible variant.
+
+### 6. Inspect targeted evidence when needed
+
+If a seam, attribution, term, or hotspot choice still needs raw evidence, spawn a fresh-context follow-up inspector for that specific line range. Require only the minimum excerpt or resolution note needed for the decision. The controller must not open the raw transcript itself.
+
+### 7. Assemble and write
+
+Before assembly, verify that every mapper-owned range has one returned `cleaned_chunk`; do not infer completion from whichever chunk returned last. Use the ledger to harmonize speaker names, attribution confidence, and technical terms, remove overlap duplication, preserve order, and assemble every owned range. Apply a stable speaker mapping and confidence level consistently across chunks unless new source evidence changes it; do not preserve accidental chunk-local confidence drift. If a suspected seam or coverage gap remains, use the targeted inspector before writing. Write to the resolved output path and overwrite an existing file at that path.
+
+Persist exactly one `<cleaned_transcript>` root element:
 
 ```xml
-<rewritten_transcript>
+<cleaned_transcript>
 Alice: First cleaned utterance.
 Bob [uncertain]: Second cleaned utterance.
 Unknown Speaker [uncertain]: Third cleaned utterance.
-</rewritten_transcript>
+</cleaned_transcript>
+```
+
+Do not put notes, open questions, coordination artifacts, or a `<rewritten_transcript>` element in the file.
+
+## Cleaner fidelity rules
+
+Brief every cleaner and hotspot challenger with all of these rules:
+
+- Format confident attribution as `Speaker: utterance`.
+- Format plausible but uncertain attribution as `Speaker [uncertain]: utterance`.
+- If no named attribution is defensible, preserve a helpful source label and mark it `[uncertain]`; otherwise use `Unknown Speaker [uncertain]: utterance`.
+- Use only those three speaker-label shapes. Do not carry source stage directions such as `[overlapping]` into the speaker label; use `[uncertain]` when cross-talk makes attribution uncertain.
+- Keep speaker order and conversational flow intact.
+- Remove filler, false starts, stutters, repetitions, silence hallucinations, and repeated `yeah`/`mm-hm` filler loops only when meaning does not change.
+- Keep an apparent filler response when it answers a yes/no question, explicitly confirms something, or carries real meaning.
+- Fix proper nouns, numbers, contractions, grammar, agreement, and technical terms only when nearby context, repeated usage, or the roster strongly supports the repair.
+- Rewrite fragments only enough to recover intended meaning.
+- Preserve every concept, claim, decision, number, and technical detail present in the source.
+- Never add information, interpretation, speaker intent, or implied context not grounded in the transcript.
+- Never summarize, combine turns, or smooth wording in ways that introduce new concepts.
+- When a word or segment cannot be recovered confidently, write `[unclear]`.
+- Use `[unclear]` only as a replacement for unrecoverable source text. Preserve a clearly spoken literal word such as “unclear” as ordinary dialogue rather than converting it to the marker.
+
+## Controller isolation rules
+
+- Never paste, quote, read, or load the full raw transcript in the controller context.
+- Keep the controller working set to the input and output paths, roster, `conversation_map`, `continuity_ledger`, rewritten chunks, open questions, hotspot variants, and small targeted excerpts returned by subagents.
+- Use subagents for all raw-transcript inspection; use the controller only for coordination, consistency decisions, assembly, and writing.
+- Do not expose the map, ledger, chunks, variants, or other coordination artifacts to the user.
+
+## Chat response
+
+After writing, start with one short path-confirmation line:
+
+`Wrote <resolved-output-path>.`
+
+Only when a significant interpretation, non-obvious speaker mapping, or material repair could affect how the transcript is read, follow the path line with a chat-only block:
+
+```xml
 <notes>
-- Brief explanation of a major repair or non-obvious speaker mapping, if needed.
+- Brief note on a material repair or non-obvious mapping.
 </notes>
 ```
+
+Omit `<notes>` when nothing material needs disclosure. An unresolved ambiguity, unanswered question, or routine `[unclear]` marker alone does not justify `<notes>`; surface it only as an open question when it is worth attention. Never write notes into the transcript file.
+
+After any material-repair notes, surface only remaining open questions worth the user's attention under a concise `Open questions:` label. Do not duplicate an open question in `<notes>`. Omit routine or resolved questions. If there are no material notes or worthwhile open questions, return only the path-confirmation line.

--- a/.codex/skills/rewrite-call-transcript/agents/openai.yaml
+++ b/.codex/skills/rewrite-call-transcript/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Rewrite Transcript"
-  short_description: "Clean transcripts with roster-guided speaker attribution"
-  default_prompt: "Use $rewrite-call-transcript to clean this transcript. Start by listing the speakers with a 2-3 word description for each person, then provide the raw transcript."
+  short_description: "Rewrite transcript files into attributed dialogue"
+  default_prompt: "Use $rewrite-call-transcript to rewrite the transcript file at /path/to/call.transcript.vtt."

--- a/.codex/skills/walk-branch-changes/SKILL.md
+++ b/.codex/skills/walk-branch-changes/SKILL.md
@@ -1,56 +1,23 @@
 ---
 name: walk-branch-changes
-description: Use when the user wants a guided review of a branch or diff in execution order through the changed behavior, with light workflow context only where needed.
+description: Use when the user wants a guided review of a branch, base ref, or Git diff range and needs the changed behavior placed in execution order.
 ---
 
-# Walk Branch Changes
+Walk the diff in execution order so the user can place the changes in the domain workflow without re-tracing the subsystem.
 
-Review branch changes in execution order through the changed behavior, so the reviewer can place the diff in the domain workflow without re-tracing the whole subsystem.
+Resolve the diff target from the user's request. Use an explicit range as given; compare a single base ref with `HEAD` using three-dot syntax; when omitted, inspect `main...HEAD`.
 
-## Workflow
+Assume the reader has broad codebase familiarity; supply only the context needed to place the diff. Lead with branch delta before implementation detail. Start chunk selection from the changed behavior, not the subsystem's public API; for internal-only changes, start from the first changed boundary.
 
-1. Start chunk selection from the branch diff and the changed behavior it introduces, not from the public API of the wider subsystem.
-2. If the changes are entirely internal, start from the first changed boundary or internal entry point that best situates the diff instead.
-3. Group related changed behavior into one bounded trace slice per chunk, even when that slice spans multiple files.
-4. Present one chunk at a time using this contract:
-   - `Chunk N`
-   - `Trace slice: <upstream event/state -> changed behavior -> downstream effect>`
-   - `3-6` numbered steps
-5. Each step must:
-   - be one sentence
-   - use namespaced domain terms already present in the codebase before generic wording
-   - describe a concrete transition: `input/event -> operation/transformation -> emitted value/state effect`
-   - include inline refs for that step, using file paths and line numbers only
-   - use exact symbol names only when they materially improve precision or editor lookup
-6. Untagged steps are presumed to be branch-relevant.
-7. If a step exists only to orient the reader between changed steps, tag it exactly `(unchanged)`.
-8. Use `0-2` `(unchanged)` steps per chunk, and keep them brief and placement-focused.
-9. Trace the primary changed path in the chunk. Mention alternate branches only when they materially change state or user-visible behavior.
-10. If an alternate path is substantial, cover it in a later chunk instead of bloating the current one.
-11. Treat schemas and shared contracts as trace steps only when the branch changed them or they are required to understand a changed boundary.
-12. After each chunk, stop and wait for the user's response before continuing.
-13. If the user asks a follow-up question or wants a deeper dive, answer it inline and then resume from the same place.
+Present one chunk at a time:
 
-## Chunk Authoring Process
+- Header line: `Chunk N — <concrete upstream event> → <concrete changed operation> → <concrete downstream effect>`. Emit that plain line without a Markdown heading prefix. Substitute domain terms inline; do not emit the placeholder labels.
+- Body: short prose paragraphs, one per causal arc. Open the chunk with the originating event (inbound trigger, or first changed boundary for internal-only changes). Close with the downstream effect (state change, persisted value, DOM update). Each paragraph traces a single causal arc through the changed code.
+- Cite `path:line` inline only on changed lines. Put each literal `path:line` immediately after the changed clause it supports and before that clause's punctuation; do not render citations as Markdown links, make a citation its own sentence, or collect references at the end of a sentence, paragraph, or chunk. Unchanged glue carries no citation — that absence is the signal.
+- Use the codebase's namespaced domain terms over generic wording; use exact symbol names only when they materially improve precision or editor lookup.
 
-For each chunk, use two passes before you respond.
+Trace the primary changed path; defer substantial alternate paths to later chunks. Include schemas or shared contracts as steps only when the branch changed them or they're needed to read a changed boundary.
 
-1. Pass 1: map the changed steps internally first, then add only the minimal `(unchanged)` bridge steps needed to make the workflow legible.
-2. Pass 2: rewrite that same chunk for display in simpler, clearer language without changing the technical meaning, sequencing, project-specific terms, or `(unchanged)` labeling that help the reader map the codebase.
+Stop after each chunk and wait. If the user asks follow-ups, answer inline and resume from the same place.
 
-## Guardrails
-
-- Assume the reader already has broad codebase familiarity; provide only the context needed to place the diff.
-- Always prefer branch delta before implementation detail.
-- Keep chunk sizes digestible; split oversized trace slices.
-- Avoid file-by-file narration when a trace slice is clearer.
-- Do not use `(unchanged)` steps to unpack internals, rationale, or long downstream effects.
-- Do not follow untouched downstream effects unless the branch materially changes them.
-- If a chunk needs more than `2` `(unchanged)` steps, split the chunk or narrow the trace slice.
-- Do not default to dense paragraph summaries.
-- Do not include code snippets.
-- Do not infer rationale, praise, critique, or coaching unless the user explicitly asks for it.
-- Do not pool refs at the end of a chunk; attach them to the steps they support.
-- Do not skip the pause between chunks.
-- Do not show the raw first-pass analysis; only show the simplified second-pass chunk.
-- Do not simplify by dropping transitions, renaming important domain terms, or replacing concrete behavior with vague summaries.
+Avoid: file-by-file narration when a trace slice is clearer; code snippets; rationale or critique unless asked; soft-renaming domain terms for prose flow; stage-managing transitions ("Now…", "Next…", "Moving on…"); padding sentences that don't carry a transition; over-summarising in a way that elides a changed step.

--- a/.codex/skills/walk-branch-changes/agents/openai.yaml
+++ b/.codex/skills/walk-branch-changes/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Walk Branch Changes"
+  short_description: "Trace a branch diff through changed behavior"
+  default_prompt: "Use $walk-branch-changes to walk my current branch against main."


### PR DESCRIPTION
- Rewrites the Codex `create-draft-pr`, `create-commit`, `walk-branch-changes`, `frame-minutes`, and `rewrite-call-transcript` skills to match the behaviour of their Claude command counterparts.
- Adds `agents/openai.yaml` manifests so these skills surface with a display name, description, and default prompt in the Codex UI.
- `rewrite-call-transcript` now takes a file path and delegates raw-transcript reading to isolated subagents, keeping the noisy source out of the controller context.
- `create-draft-pr` no longer asks for confirmation before pushing and creating — invocation is the authorization; fewer round trips, but a mistaken invocation now opens a PR directly.
- `strategic-artifact`'s lineage map also walks `.html` artifacts, not just `.md`.